### PR TITLE
feat: add GitHub Codespaces support for demo

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     }
   },
   "postCreateCommand": "npm install && pip install -r ml-model/requirements.txt && npm run build",
+  "postStartCommand": "bash scripts/codespaces-start.sh",
   "forwardPorts": [3001, 5174, 8000],
   "portsAttributes": {
     "5174": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+{
+  "name": "NullVoid",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    }
+  },
+  "postCreateCommand": "npm install && pip install -r ml-model/requirements.txt && npm run build",
+  "forwardPorts": [3001, 5174, 8000],
+  "portsAttributes": {
+    "5174": {
+      "label": "Dashboard",
+      "onAutoForward": "openPreview"
+    },
+    "3001": {
+      "label": "API"
+    },
+    "8000": {
+      "label": "ML Serve"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": []
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -617,14 +617,7 @@ make install && make build && make test
 
 ### Try in GitHub Codespaces
 
-Run NullVoid (including the ML pipeline) in the cloud—no local install. Click **Code** → **Codespaces** → **Create codespace on main**. After the container builds:
-
-```bash
-make api        # Terminal 1: start API
-make dashboard  # Terminal 2: start dashboard
-```
-
-Open the forwarded port **5174** (Dashboard). Use the ML page to export features and train models. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#github-codespaces-demo) for details.
+Run NullVoid (including the ML pipeline) in the cloud—no local install. Click **Code** → **Codespaces** → **Create codespace on main**. After the container builds, API and Dashboard start automatically. Open the forwarded port **5174** (Dashboard). Use the ML page to export features and train models. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#github-codespaces-demo) for details.
 
 ## 🔧 **TypeScript Support**
 

--- a/README.md
+++ b/README.md
@@ -615,6 +615,17 @@ make install && make build && make test
 # or: npm ci && npm run build && npm test
 ```
 
+### Try in GitHub Codespaces
+
+Run NullVoid (including the ML pipeline) in the cloud—no local install. Click **Code** → **Codespaces** → **Create codespace on main**. After the container builds:
+
+```bash
+make api        # Terminal 1: start API
+make dashboard  # Terminal 2: start dashboard
+```
+
+Open the forwarded port **5174** (Dashboard). Use the ML page to export features and train models. See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#github-codespaces-demo) for details.
+
 ## 🔧 **TypeScript Support**
 
 NullVoid is built with **TypeScript** for enhanced type safety and developer experience. The project uses **Turborepo** for the monorepo build pipeline (workspaces: `packages/*`, `ts`, `js`). **Node 20+** is required for building (some dependencies require it).

--- a/docs/CODESPACES-PLAN.md
+++ b/docs/CODESPACES-PLAN.md
@@ -1,0 +1,131 @@
+# GitHub Codespaces Plan
+
+**Goal:** Enable NullVoid to run as a demo in GitHub Codespaces (100% free, no credit card) so contributors and reviewers can try the ML pipeline without local setup.
+
+---
+
+## Phase 1: Dev Container Setup
+
+### 1.1 Create `.devcontainer` directory
+
+```
+.devcontainer/
+├── devcontainer.json
+└── Dockerfile (optional; use image if sufficient)
+```
+
+### 1.2 Base image
+
+- Use `mcr.microsoft.com/devcontainers/javascript-node` (Node 20 LTS) or
+- `ghcr.io/devcontainers/javascript-node` with Python feature
+- Alternative: `mcr.microsoft.com/devcontainers/universal` (Node + Python + common tools)
+
+### 1.3 Features to add
+
+| Feature | Purpose |
+|---------|---------|
+| `ghcr.io/devcontainers/features/python` | Python 3.11+ for ML (scikit-learn, xgboost, fastapi) |
+| `ghcr.io/devcontainers/features/git` | Already in base; ensure Git available |
+
+### 1.4 `devcontainer.json` config
+
+- **postCreateCommand:** Run once when Codespace is created
+  - `npm install`
+  - `pip install -r ml-model/requirements.txt`
+  - `npm run build` (builds ts, api, dashboard)
+- **forwardPorts:** `[3001, 5174, 8000]`
+- **customizations:** VS Code extensions (optional: ESLint, Prettier, Python)
+- **postStartCommand:** (optional) Echo reminder: "Run `make api` and `make dashboard` to start"
+
+---
+
+## Phase 2: Documentation
+
+### 2.1 Add Codespaces section to README
+
+- "Try in Codespaces" button (GitHub provides this when `.devcontainer` exists)
+- Short "Codespaces demo" subsection:
+  - Open repo in Codespaces
+  - Run `make api` (terminal 1), `make dashboard` (terminal 2)
+  - Open port 5174
+  - ML page: Export → Train
+
+### 2.2 Update `docs/DEPLOYMENT.md`
+
+- Add "GitHub Codespaces (Demo)" section
+- Clarify: Codespaces = demo/dev; Vercel = production deployment
+
+---
+
+## Phase 3: Optional Improvements
+
+### 3.1 Startup script (optional)
+
+- `scripts/codespaces-start.sh`: Start API + dashboard in background, print URLs
+- Reduces manual steps for first-time users
+
+### 3.2 Pre-commit / CI check (optional)
+
+- Ensure `.devcontainer` is valid (e.g. `devcontainer validate` in CI)
+- Low priority for demo use case
+
+### 3.3 ML pre-trained models
+
+- `train.jsonl` and `train-behavioral.jsonl` already in repo
+- `model.pkl` / `behavioral-model.pkl` could be committed (if small) so demo works without running train
+- Or: document that first Export+Train takes ~1–2 min
+
+---
+
+## Phase 4: Verification
+
+### 4.1 Manual test
+
+1. Push `.devcontainer` to repo
+2. Click "Code" → "Codespaces" → "Create codespace on main"
+3. Wait for postCreateCommand to finish
+4. Run `make api` and `make dashboard`
+5. Open forwarded port 5174
+6. Verify: Scans page, ML page (Export, Train), Reports
+
+### 4.2 Checklist
+
+- [ ] `npm install` succeeds (better-sqlite3 compiles)
+- [ ] `pip install -r ml-model/requirements.txt` succeeds
+- [ ] `npm run build` succeeds
+- [ ] API starts on 3001
+- [ ] Dashboard proxies to API, loads on 5174
+- [ ] ML Export / Train buttons work
+- [ ] Port 5174 accessible via Codespaces URL
+
+---
+
+## File Changes Summary
+
+| File | Action |
+|------|--------|
+| `.devcontainer/devcontainer.json` | Create |
+| `.devcontainer/Dockerfile` | Optional (use features if image sufficient) |
+| `README.md` | Add Codespaces subsection |
+| `docs/DEPLOYMENT.md` | Add Codespaces section |
+| `docs/CODESPACES-PLAN.md` | This plan |
+
+---
+
+## Effort Estimate
+
+| Phase | Effort |
+|-------|--------|
+| Phase 1 (devcontainer) | 30–60 min |
+| Phase 2 (docs) | 15 min |
+| Phase 3 (optional) | 30 min |
+| Phase 4 (verification) | 15 min |
+| **Total** | ~1–2 hours |
+
+---
+
+## Out of Scope
+
+- Production deployment on Codespaces (ephemeral, not 24/7)
+- Turso in Codespaces (SQLite is fine for demo)
+- Vercel config changes (unchanged)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -2,6 +2,27 @@
 
 Both the **Dashboard** and **API** deploy to **Vercel** when you connect this repository.
 
+## GitHub Codespaces (Demo)
+
+Run NullVoid in the cloud for demos or development—100% free (60 hours/month), no credit card. The `.devcontainer` config installs Node, Python, and dependencies automatically.
+
+### Setup
+
+1. Open the repo on GitHub → **Code** → **Codespaces** → **Create codespace on main**
+2. Wait for the container to build (postCreateCommand runs `npm install`, `pip install`, `npm run build`)
+3. In one terminal: `make api`
+4. In another terminal: `make dashboard`
+5. Open the forwarded port **5174** (Dashboard) in your browser
+
+### ML Pipeline
+
+The ML page (Export, Train) works in Codespaces. Use SQLite (no Turso needed). Optional: `make ml-serve` for the scoring API on port 8000.
+
+### Notes
+
+- Codespaces is ephemeral—not for 24/7 production
+- For production deployment, use [Vercel](#vercel-dashboard--api)
+
 ## Vercel (Dashboard + API)
 
 A single Vercel project serves the **Dashboard** at `/` and the **API** at `/api`. The API deploys when you connect this repository. Vercel uses **Turso** (serverless SQLite) for the database—SQLite files do not work on Vercel's read-only filesystem.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -10,9 +10,7 @@ Run NullVoid in the cloud for demos or development—100% free (60 hours/month),
 
 1. Open the repo on GitHub → **Code** → **Codespaces** → **Create codespace on main**
 2. Wait for the container to build (postCreateCommand runs `npm install`, `pip install`, `npm run build`)
-3. In one terminal: `make api`
-4. In another terminal: `make dashboard`
-5. Open the forwarded port **5174** (Dashboard) in your browser
+3. API and Dashboard start automatically (postStartCommand). Open the forwarded port **5174** (Dashboard) in your browser
 
 ### ML Pipeline
 

--- a/scripts/codespaces-start.sh
+++ b/scripts/codespaces-start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Start API and Dashboard in background (for Codespaces postStartCommand)
+cd "$(dirname "$0")/.." || exit 1
+make api > /tmp/nullvoid-api.log 2>&1 &
+sleep 5
+make dashboard > /tmp/nullvoid-dashboard.log 2>&1 &
+echo "API (3001) and Dashboard (5174) starting in background. Check Ports panel."


### PR DESCRIPTION
- Add .devcontainer with Node 22 + Python 3.11
- postCreateCommand: npm install, pip install, npm run build
- Forward ports 3001 (API), 5174 (Dashboard), 8000 (ML)
- Update README with Try in Codespaces section
- Add Codespaces section to docs/DEPLOYMENT.md
- Add docs/CODESPACES-PLAN.md

## Description
Brief description of changes.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] Tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Lint passes (`npm run lint`)

## Related issues
Fixes #
