### PR TITLE
feat: Wire Redis L3 cache to CLI and IoC stats (#23)

### DIFF
--- a/.cursor/skills/regression/SKILL.md
+++ b/.cursor/skills/regression/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: regression
+description: >-
+  Runs NullVoid regression validation — CI parity, performance benchmarks, optional
+  ML held-out eval, and baseline comparison. Use when the user invokes /regression,
+  asks to check for regressions, validate before merge, or compare perf/ML metrics
+  to baseline.
+disable-model-invocation: true
+---
+
+# NullVoid Regression (/regression)
+
+Validate no regressions before merge or after risky changes.
+
+| Constant | Value |
+|----------|-------|
+| Repo | `kurt-grung/NullVoid` |
+| Root | `/Users/kurtgrung/Desktop/NullVoid` (or your clone) |
+| CI parity | `npm run ci:check` → `scripts/ci-check.sh` |
+| Roadmap epic | [#26 Performance regression suite](https://github.com/kurt-grung/NullVoid/issues/26) |
+
+Requires Node 20.x and `npm ci` when lockfile or deps changed.
+
+## Modes
+
+| User intent | Action |
+|-------------|--------|
+| `/regression` or "full regression" | Tier 1 + Tier 2; Tier 3 when Python ML deps available |
+| `/regression quick` | Tier 1 only |
+| `/regression perf` | Tier 2 only |
+| `/regression ml` | Tier 3 only |
+| `/regression compare` | Tier 3 + compare to latest CI `ml-eval-report` artifact |
+
+Stop on first failing tier unless the user asked to run everything and report all failures.
+
+## Tier 1 — CI parity (required)
+
+```bash
+cd "${ROOT}"
+npm run ci:check
+```
+
+Covers: build, lint, type-check, format, unit-test isolation verify, `npm test` (unit + integration + performance via Jest projects).
+
+Individual steps when isolating a failure:
+
+```bash
+npm run build
+npm run lint
+npm run type-check
+npm run format:check
+bash .github/scripts/verify-unit-test-isolation.sh
+npm test
+```
+
+**Unit test rule:** tests under `ts/test/unit/` must not hit live IoC APIs — use mocks or `jest.spyOn(getIoCManager(), 'queryAll')`.
+
+## Tier 2 — Performance
+
+```bash
+npm run test:performance
+```
+
+Benchmarks live in `ts/test/performance/` (scan time ceiling, future IoC batching / parallel worker gates per roadmap).
+
+If dashboard files changed in the current branch or working tree:
+
+```bash
+npm run dashboard:build
+```
+
+## Tier 3 — ML held-out eval (optional, heavier)
+
+Requires Python 3.11+ and `python3 -m pip install -r ml-model/requirements.txt`.
+
+```bash
+npm run ml:heldout-dependency
+```
+
+Behavioral held-out (when investigating behavioral ML changes):
+
+```bash
+npm run ml:split-train-val -- \
+  --input ml-model/train-behavioral.jsonl \
+  --train-out ml-model/.eval-cache/beh-train.jsonl \
+  --val-out ml-model/.eval-cache/beh-val.jsonl \
+  --val-fraction 0.2 --seed 42 \
+  --time-val-newest --time-field exportedAt
+npm run ml:train-behavioral -- --input ml-model/.eval-cache/beh-train.jsonl --output-dir ml-model/.eval-cache/beh
+node ts/dist/bin/nullvoid.js eval-behavioral \
+  --input ml-model/.eval-cache/beh-val.jsonl \
+  --model ml-model/.eval-cache/beh/behavioral-model.pkl \
+  --keys ml-model/.eval-cache/beh/behavioral-feature_keys.pkl --json
+```
+
+Skip Tier 3 when the change does not touch `ml-model/`, `ts/src/**/ml*`, or behavioral scoring — note the skip in the report.
+
+## Compare to CI baseline (`/regression compare`)
+
+1. Run Tier 3 locally; save JSON output.
+2. Fetch latest green **Tests** workflow artifact:
+
+```bash
+RUN_ID=$(gh run list --repo kurt-grung/NullVoid --workflow=tests.yml --branch=main --status=success --limit 1 --json databaseId -q '.[0].databaseId')
+mkdir -p /tmp/ml-baseline && gh run download "${RUN_ID}" --repo kurt-grung/NullVoid --name ml-eval-report --dir /tmp/ml-baseline
+```
+
+3. Compare `roc_auc`, `precision`, and `recall` for dependency and behavioral models. Flag regressions when a metric drops more than ~2 pp vs baseline (or any CI floor breach).
+
+See `ml-model/README.md` — **Drift / regression tracking**.
+
+## Report format
+
+After the run, return a compact summary:
+
+```markdown
+## Regression report
+
+| Tier | Status | Notes |
+|------|--------|-------|
+| CI parity | pass/fail | … |
+| Performance | pass/fail/skip | duration if relevant |
+| ML held-out | pass/fail/skip | key metrics |
+| vs CI baseline | pass/fail/n/a | deltas |
+
+### Failures
+- <command>: <first error line or test name>
+
+### Next steps
+- <scoped fix or re-run command>
+```
+
+On failure: fix the root cause in scope, re-run the failed tier only, then re-run full `/regression` before merge.
+
+## When to invoke
+
+- Before opening or merging a PR (especially detection, API, dashboard, ML)
+- After resolving merge conflicts or rebasing onto `main`
+- After dependency bumps (`package-lock.json`, `ml-model/requirements.txt`)
+- When investigating suspected perf or ML metric drift
+
+## Optional — verifier subagent
+
+After all tiers pass and the change is user-facing (dashboard, API contract, CLI output), launch the **verifier** subagent to smoke-test the implementation. Do not launch verifier on test-only or docs-only runs unless the user asks.
+
+## Quick reference
+
+```bash
+npm run ci:check
+npm run test:performance
+npm run dashboard:build
+npm run ml:heldout-dependency
+gh run list --repo kurt-grung/NullVoid --workflow=tests.yml --limit 5
+```

--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,9 @@ pids
 *.pid.lock
 
 # IDE files
-.cursor/
+.cursor/*
+!.cursor/skills/
+!.cursor/skills/**
 .vscode/
 .idea/
 *.swp

--- a/package-lock.json
+++ b/package-lock.json
@@ -2265,6 +2265,78 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -5256,6 +5328,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6761,6 +6843,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/gensync": {
@@ -10276,6 +10368,24 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
       }
     },
     "node_modules/redux": {
@@ -14171,6 +14281,9 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "redis": "^4.7.0"
       }
     },
     "ts/node_modules/@babel/code-frame": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -84,6 +84,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },
+  "optionalDependencies": {
+    "redis": "^4.7.0"
+  },
   "overrides": {
     "js-yaml": "^4.1.1"
   },

--- a/ts/src/bin/nullvoid.ts
+++ b/ts/src/bin/nullvoid.ts
@@ -29,6 +29,7 @@ import {
   TRUST_CONFIG,
   BLOCKCHAIN_CONFIG,
   CONSENSUS_CONFIG,
+  applyCacheCliOptions,
   getRcScanOptions,
 } from '../lib/config';
 import colors from '../colors';
@@ -1219,6 +1220,8 @@ program
   });
 
 async function performScan(target: string | undefined, options: CliOptions) {
+  applyCacheCliOptions({ enableRedis: Boolean(options['enable-redis']) });
+
   const spinner = ora('🔍 Scanning ...').start();
 
   try {
@@ -1477,13 +1480,31 @@ async function performScan(target: string | undefined, options: CliOptions) {
         const multiLayerStats = cacheAnalytics.getSummary(statsForSummary);
 
         console.log('\n📊 Cache Statistics:');
-        console.log(`   L1 (Memory) Cache:`);
-        const l1Stats = multiLayerStats.layers['L1'];
-        if (l1Stats) {
-          console.log(`     Hit Rate: ${(l1Stats.hitRate * 100).toFixed(2)}%`);
-          console.log(`     Utilization: ${(l1Stats.utilization * 100).toFixed(2)}%`);
-          console.log(`     Size: ${l1Stats.size} items`);
+        const layerLabels: Record<string, string> = {
+          L1: 'Memory',
+          L2: 'File',
+          L3: 'Redis',
+        };
+        for (const layerKey of ['L1', 'L2', 'L3'] as const) {
+          const layerStats = multiLayerStats.layers[layerKey];
+          if (!layerStats) {
+            continue;
+          }
+          console.log(`   ${layerKey} (${layerLabels[layerKey]}) Cache:`);
+          console.log(`     Hit Rate: ${(layerStats.hitRate * 100).toFixed(2)}%`);
+          console.log(`     Utilization: ${(layerStats.utilization * 100).toFixed(2)}%`);
+          console.log(`     Size: ${layerStats.size} items`);
         }
+
+        if ('layers' in cacheStats) {
+          const l3Status = ioCManager.getL3CacheStatus();
+          if (l3Status?.enabled) {
+            console.log(
+              `   L3 Redis: ${l3Status.connected ? 'connected' : 'disconnected (using L1/L2 fallback)'}`
+            );
+          }
+        }
+
         if (multiLayerStats.recommendations.length > 0) {
           console.log(`   Recommendations:`);
           multiLayerStats.recommendations.forEach((rec) => console.log(`     - ${rec}`));

--- a/ts/src/lib/cache/cacheAnalytics.ts
+++ b/ts/src/lib/cache/cacheAnalytics.ts
@@ -63,6 +63,10 @@ export class CacheAnalytics {
       );
     }
 
+    if (stats.layers.L3.hits + stats.layers.L3.misses > 0 && stats.layers.L3.hitRate < 0.2) {
+      recommendations.push('L3 cache hit rate is low. Verify Redis connectivity and TTL settings.');
+    }
+
     // Overall recommendations
     if (stats.overallHitRate < 0.3) {
       recommendations.push(

--- a/ts/src/lib/cache/multiLayerCache.ts
+++ b/ts/src/lib/cache/multiLayerCache.ts
@@ -226,6 +226,14 @@ export class MultiLayerCache<T = unknown> {
       }
     }
 
+    if (this.l3Enabled && this.l3Cache) {
+      try {
+        await this.l3Cache.clear();
+      } catch (error) {
+        logger.warn(`Failed to clear L3 cache`, { error: String(error) });
+      }
+    }
+
     // Reset stats
     this.stats.l1 = this.createEmptyStats('L1');
     this.stats.l2 = this.createEmptyStats('L2');
@@ -236,6 +244,13 @@ export class MultiLayerCache<T = unknown> {
     if (this.l3Cache) {
       await this.l3Cache.close();
     }
+  }
+
+  getL3Status(): ReturnType<RedisCache['getStatus']> | null {
+    if (!this.l3Enabled || !this.l3Cache) {
+      return null;
+    }
+    return this.l3Cache.getStatus();
   }
 
   /**
@@ -266,6 +281,7 @@ export class MultiLayerCache<T = unknown> {
     if (this.l3Enabled && this.l3Cache) {
       const status = this.l3Cache.getStatus();
       this.stats.l3.utilization = status.connected ? 1 : 0;
+      this.stats.l3.size = status.connected ? this.stats.l3.hits + this.stats.l3.misses : 0;
     }
 
     return {

--- a/ts/src/lib/cache/redisCache.ts
+++ b/ts/src/lib/cache/redisCache.ts
@@ -7,6 +7,8 @@ import type { L3CacheConfig } from '../../types/cache-types';
 import { CACHE_LAYER_CONFIG } from '../config';
 import { logger } from '../logger';
 
+const REDIS_KEY_PREFIX = 'nullvoid:cache:';
+
 /**
  * Redis client interface (to avoid requiring redis as a dependency)
  */
@@ -29,6 +31,7 @@ export class RedisCache {
   private available = false;
   private connectionAttempts = 0;
   private readonly maxConnectionAttempts = 3;
+  private trackedKeys = new Set<string>();
 
   constructor(config?: Partial<L3CacheConfig>) {
     this.config = {
@@ -153,13 +156,17 @@ export class RedisCache {
   /**
    * Get value from Redis
    */
+  private redisKey(key: string): string {
+    return `${REDIS_KEY_PREFIX}${key}`;
+  }
+
   async get<T>(key: string): Promise<T | null> {
     if (!this.config.enabled || !this.available || !this.client) {
       return null;
     }
 
     try {
-      const value = await this.client.get(key);
+      const value = await this.client.get(this.redisKey(key));
       if (value === null) {
         return null;
       }
@@ -200,7 +207,9 @@ export class RedisCache {
       const ttlSeconds = ttl ? Math.floor(ttl / 1000) : undefined;
 
       if (this.client) {
-        await this.client.set(key, serialized, ttlSeconds ? { EX: ttlSeconds } : undefined);
+        const redisKey = this.redisKey(key);
+        await this.client.set(redisKey, serialized, ttlSeconds ? { EX: ttlSeconds } : undefined);
+        this.trackedKeys.add(redisKey);
         return true;
       }
       return false;
@@ -220,7 +229,9 @@ export class RedisCache {
     }
 
     try {
-      const result = await this.client.del(key);
+      const redisKey = this.redisKey(key);
+      const result = await this.client.del(redisKey);
+      this.trackedKeys.delete(redisKey);
       return result > 0;
     } catch (error) {
       logger.debug(`Redis delete error for key ${key}`, { error: String(error) });
@@ -238,7 +249,7 @@ export class RedisCache {
     }
 
     try {
-      const result = await this.client.exists(key);
+      const result = await this.client.exists(this.redisKey(key));
       return result > 0;
     } catch (error) {
       logger.debug(`Redis exists error for key ${key}`, { error: String(error) });
@@ -270,9 +281,21 @@ export class RedisCache {
     };
   }
 
-  /**
-   * Close Redis connection
-   */
+  async clear(): Promise<void> {
+    if (!this.config.enabled || !this.available || !this.client) {
+      return;
+    }
+
+    for (const redisKey of this.trackedKeys) {
+      try {
+        await this.client.del(redisKey);
+      } catch (error) {
+        logger.debug(`Redis clear error for key ${redisKey}`, { error: String(error) });
+      }
+    }
+    this.trackedKeys.clear();
+  }
+
   async close(): Promise<void> {
     if (this.client) {
       try {

--- a/ts/src/lib/config.ts
+++ b/ts/src/lib/config.ts
@@ -1196,6 +1196,11 @@ export function updateConfigFromEnv(): void {
     (CACHE_LAYER_CONFIG.L3 as Record<string, unknown>)['enabled'] = enabled;
   }
 
+  if (process.env['NULLVOID_IOC_MULTI_LAYER_CACHE']) {
+    const enabled = process.env['NULLVOID_IOC_MULTI_LAYER_CACHE'].toLowerCase() === 'true';
+    (IOC_CONFIG as Record<string, unknown>)['USE_MULTI_LAYER_CACHE'] = enabled;
+  }
+
   // Update network optimization settings
   if (process.env['NULLVOID_CONNECTION_POOL_ENABLED']) {
     const enabled = process.env['NULLVOID_CONNECTION_POOL_ENABLED'].toLowerCase() === 'true';
@@ -1211,6 +1216,15 @@ export function updateConfigFromEnv(): void {
     const enabled = process.env['NULLVOID_COMPRESSION_ENABLED'].toLowerCase() === 'true';
     (NETWORK_OPTIMIZATION_CONFIG.COMPRESSION as Record<string, unknown>)['enabled'] = enabled;
   }
+}
+
+export function applyCacheCliOptions(options: { enableRedis?: boolean }): void {
+  if (!options.enableRedis) {
+    return;
+  }
+
+  (CACHE_LAYER_CONFIG.L3 as Record<string, unknown>)['enabled'] = true;
+  (IOC_CONFIG as Record<string, unknown>)['USE_MULTI_LAYER_CACHE'] = true;
 }
 
 // Export VALIDATION_CONFIG for backward compatibility

--- a/ts/src/lib/iocIntegration.ts
+++ b/ts/src/lib/iocIntegration.ts
@@ -17,6 +17,7 @@ import type {
 import type { MultiLayerCacheStats } from '../types/cache-types';
 import { LRUCache } from './cache';
 import { MultiLayerCache } from './cache/multiLayerCache';
+import type { RedisCache } from './cache/redisCache';
 import { getCacheAnalytics } from './cache/cacheAnalytics';
 import { IOC_CONFIG } from './config';
 import { logger } from './logger';
@@ -351,6 +352,14 @@ export class IoCIntegrationManager {
       return stats;
     }
     return (this.cache as LRUCache<IoCResponse>).getStats();
+  }
+
+  getL3CacheStatus(): ReturnType<RedisCache['getStatus']> | null {
+    if (!this.useMultiLayer) {
+      return null;
+    }
+    const multiLayer = this.cache as MultiLayerCache<IoCResponse>;
+    return multiLayer.getL3Status();
   }
 
   /**

--- a/ts/test/unit/cache-cli-config.test.ts
+++ b/ts/test/unit/cache-cli-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  applyCacheCliOptions,
+  CACHE_LAYER_CONFIG,
+  IOC_CONFIG,
+} from '../../src/lib/config';
+
+describe('applyCacheCliOptions', () => {
+  const originalL3Enabled = (CACHE_LAYER_CONFIG.L3 as { enabled: boolean }).enabled;
+  const originalMultiLayer = IOC_CONFIG.USE_MULTI_LAYER_CACHE;
+
+  beforeEach(() => {
+    (CACHE_LAYER_CONFIG.L3 as Record<string, unknown>)['enabled'] = false;
+    (IOC_CONFIG as Record<string, unknown>)['USE_MULTI_LAYER_CACHE'] = false;
+  });
+
+  afterEach(() => {
+    (CACHE_LAYER_CONFIG.L3 as Record<string, unknown>)['enabled'] = originalL3Enabled;
+    (IOC_CONFIG as Record<string, unknown>)['USE_MULTI_LAYER_CACHE'] = originalMultiLayer;
+  });
+
+  it('enables L3 and multi-layer IoC cache when enableRedis is true', () => {
+    applyCacheCliOptions({ enableRedis: true });
+
+    expect((CACHE_LAYER_CONFIG.L3 as { enabled: boolean }).enabled).toBe(true);
+    expect(IOC_CONFIG.USE_MULTI_LAYER_CACHE).toBe(true);
+  });
+
+  it('does not change config when enableRedis is false', () => {
+    applyCacheCliOptions({ enableRedis: false });
+
+    expect((CACHE_LAYER_CONFIG.L3 as { enabled: boolean }).enabled).toBe(false);
+    expect(IOC_CONFIG.USE_MULTI_LAYER_CACHE).toBe(false);
+  });
+});

--- a/ts/test/unit/redis-l3-cache.test.ts
+++ b/ts/test/unit/redis-l3-cache.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+
+const mockStore = new Map<string, unknown>();
+
+jest.mock('../../src/lib/cache/redisCache', () => ({
+  createRedisCache: jest.fn(() => ({
+    get: jest.fn(async <T>(key: string): Promise<T | null> => {
+      const value = mockStore.get(key);
+      return value !== undefined ? (value as T) : null;
+    }),
+    set: jest.fn(async (key: string, value: unknown) => {
+      mockStore.set(key, value);
+      return true;
+    }),
+    delete: jest.fn(async (key: string) => {
+      const existed = mockStore.has(key);
+      mockStore.delete(key);
+      return existed;
+    }),
+    clear: jest.fn(async () => {
+      mockStore.clear();
+    }),
+    getStatus: jest.fn(() => ({
+      enabled: true,
+      available: true,
+      connected: true,
+      connectionAttempts: 0,
+    })),
+    close: jest.fn(async () => undefined),
+  })),
+}));
+
+import { MultiLayerCache } from '../../src/lib/cache/multiLayerCache';
+import { CACHE_LAYER_CONFIG } from '../../src/lib/config';
+
+describe('MultiLayerCache L3 integration', () => {
+  let cache: MultiLayerCache<string>;
+  const originalL3Enabled = (CACHE_LAYER_CONFIG.L3 as { enabled: boolean }).enabled;
+
+  beforeEach(() => {
+    mockStore.clear();
+    (CACHE_LAYER_CONFIG.L3 as Record<string, unknown>)['enabled'] = true;
+    cache = new MultiLayerCache<string>();
+  });
+
+  afterEach(async () => {
+    await cache.clear();
+    await cache.close();
+    (CACHE_LAYER_CONFIG.L3 as Record<string, unknown>)['enabled'] = originalL3Enabled;
+  });
+
+  it('reads from L3 when L1 and L2 miss', async () => {
+    mockStore.set('remote-key', 'remote-value');
+
+    const result = await cache.get('remote-key');
+
+    expect(result.success).toBe(true);
+    expect(result.value).toBe('remote-value');
+    expect(result.layer).toBe('L3');
+  });
+
+  it('writes through to L3 on set', async () => {
+    await cache.set('persist-key', 'persist-value');
+
+    expect(mockStore.get('persist-key')).toBe('persist-value');
+  });
+
+  it('reports L3 stats after hits', async () => {
+    mockStore.set('stats-key', 'stats-value');
+    await cache.get('stats-key');
+
+    const stats = cache.getStats();
+
+    expect(stats.layers.L3.hits).toBe(1);
+    expect(stats.layers.L3.hitRate).toBe(1);
+    expect(cache.getL3Status()?.connected).toBe(true);
+  });
+
+  it('clears L3 entries', async () => {
+    await cache.set('clear-key', 'clear-value');
+    await cache.clear();
+
+    expect(mockStore.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Wire `--enable-redis` to enable L3 Redis and multi-layer IoC cache via `applyCacheCliOptions`
- Complete L3 lifecycle in `multiLayerCache` (clear, stats, connection status) and namespaced Redis keys
- Show L1/L2/L3 cache stats and Redis connection status in `--cache-stats` output

## Roadmap

Closes #23

Epic: Implement Redis L3 cache
Project: https://github.com/users/kurt-grung/projects/3

## Test plan

- [x] `npm run ci:check`
- [x] `cd ts && npm test -- test/unit/cache-cli-config.test.ts test/unit/redis-l3-cache.test.ts`
- [ ] `nullvoid . --enable-redis --cache-stats` with Redis running shows L3 connected