### PR TITLE
feat: Complete remote npm package scanning (#24)

### DIFF
--- a/docs/ADVANCED_ROADMAP.md
+++ b/docs/ADVANCED_ROADMAP.md
@@ -21,7 +21,6 @@ See also: [ROADMAP.md](ROADMAP.md) (release history and current status), [dashbo
 | Gap | Location |
 |-----|----------|
 | L3 Redis cache stub | `ts/src/lib/cache/multiLayerCache.ts` |
-| Remote npm package scan placeholder | `ts/src/scan.ts` |
 | ML runtime rule-based + optional HTTP | `ts/src/lib/mlDetection.ts` |
 | No webhooks, GraphQL, schedules, audit log | `packages/api/src/index.ts` |
 | Dual `js/` + `ts/` maintenance | `js/` workspace |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,6 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
+    "pretest": "npm run build -w @nullvoid/ts",
     "test": "jest --runInBand"
   },
   "dependencies": {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -29,6 +29,7 @@ import {
 } from './db';
 import { registerEnterpriseRoutes, dispatchWebhooks, appendAudit } from './enterprise/routes';
 import { startScheduleRunner } from './enterprise/jobs';
+import { sanitizeScanTarget } from './scanTarget';
 
 /** Wrap async route handlers so rejections reach error middleware */
 const asyncHandler =
@@ -203,22 +204,6 @@ function requireTenantHeaders(
   return tenant;
 }
 
-function sanitizeScanTarget(rawTarget: unknown): { display: string; resolved: string } {
-  const candidate = typeof rawTarget === 'string' ? rawTarget.trim() : '.';
-  const normalizedInput = candidate.length > 0 ? candidate : '.';
-  if (normalizedInput.includes('\0')) {
-    throw new Error('Target contains invalid null byte');
-  }
-  const resolved = path.isAbsolute(normalizedInput)
-    ? path.resolve(normalizedInput)
-    : path.resolve(SCAN_ROOT, normalizedInput);
-  const relative = path.relative(SCAN_ROOT, resolved);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
-    throw new Error(`Target must resolve inside configured scan root: ${SCAN_ROOT}`);
-  }
-  return { display: normalizedInput, resolved };
-}
-
 function parseResultJson(
   rawResultJson: string | null
 ): Record<string, unknown> | undefined {
@@ -308,7 +293,10 @@ app.post(
     let displayTarget: string;
     let resolvedTarget: string;
     try {
-      ({ display: displayTarget, resolved: resolvedTarget } = sanitizeScanTarget(req.body?.target));
+      ({ display: displayTarget, resolved: resolvedTarget } = sanitizeScanTarget(
+        req.body?.target,
+        SCAN_ROOT
+      ));
     } catch (error) {
       res.status(400).json({ error: (error as Error).message });
       return;

--- a/packages/api/src/scanTarget.ts
+++ b/packages/api/src/scanTarget.ts
@@ -1,0 +1,58 @@
+import * as path from 'path';
+
+const tsDist = path.resolve(__dirname, '../../../ts/dist');
+
+type RemoteScanHelpers = {
+  isNpmPackageSpec: (target: string) => boolean;
+  parsePackageSpec: (spec: string) => { name: string; version: string } | null;
+  validatePackageName: (name: string) => boolean;
+};
+
+let remoteScanHelpers: RemoteScanHelpers | null = null;
+
+function getRemoteScanHelpers(): RemoteScanHelpers {
+  if (!remoteScanHelpers) {
+    const remote = require(path.join(tsDist, 'lib/remotePackageScan')) as {
+      isNpmPackageSpec: RemoteScanHelpers['isNpmPackageSpec'];
+      parsePackageSpec: RemoteScanHelpers['parsePackageSpec'];
+    };
+    const pathSec = require(path.join(tsDist, 'lib/pathSecurity')) as {
+      validatePackageName: RemoteScanHelpers['validatePackageName'];
+    };
+    remoteScanHelpers = {
+      isNpmPackageSpec: remote.isNpmPackageSpec,
+      parsePackageSpec: remote.parsePackageSpec,
+      validatePackageName: pathSec.validatePackageName,
+    };
+  }
+  return remoteScanHelpers;
+}
+
+export function sanitizeScanTarget(
+  rawTarget: unknown,
+  scanRoot: string
+): { display: string; resolved: string } {
+  const candidate = typeof rawTarget === 'string' ? rawTarget.trim() : '.';
+  const normalizedInput = candidate.length > 0 ? candidate : '.';
+  if (normalizedInput.includes('\0')) {
+    throw new Error('Target contains invalid null byte');
+  }
+
+  const { isNpmPackageSpec, parsePackageSpec, validatePackageName } = getRemoteScanHelpers();
+  if (isNpmPackageSpec(normalizedInput)) {
+    const spec = parsePackageSpec(normalizedInput);
+    if (!spec || !validatePackageName(spec.name)) {
+      throw new Error('Invalid npm package name');
+    }
+    return { display: normalizedInput, resolved: normalizedInput };
+  }
+
+  const resolved = path.isAbsolute(normalizedInput)
+    ? path.resolve(normalizedInput)
+    : path.resolve(scanRoot, normalizedInput);
+  const relative = path.relative(scanRoot, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Target must resolve inside configured scan root: ${scanRoot}`);
+  }
+  return { display: normalizedInput, resolved };
+}

--- a/packages/api/test/scan-target.test.ts
+++ b/packages/api/test/scan-target.test.ts
@@ -7,10 +7,6 @@ const scanRoot = path.join(os.tmpdir(), 'nullvoid-scan-target-root');
 
 beforeAll(() => {
   fs.mkdirSync(scanRoot, { recursive: true });
-  const tsDistRemote = path.resolve(__dirname, '../../../ts/dist/lib/remotePackageScan.js');
-  if (!fs.existsSync(tsDistRemote)) {
-    throw new Error('ts/dist not found — run npm run build before api tests');
-  }
 });
 
 describe('sanitizeScanTarget', () => {

--- a/packages/api/test/scan-target.test.ts
+++ b/packages/api/test/scan-target.test.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { sanitizeScanTarget } from '../src/scanTarget';
+
+const scanRoot = path.join(os.tmpdir(), 'nullvoid-scan-target-root');
+
+beforeAll(() => {
+  fs.mkdirSync(scanRoot, { recursive: true });
+  const tsDistRemote = path.resolve(__dirname, '../../../ts/dist/lib/remotePackageScan.js');
+  if (!fs.existsSync(tsDistRemote)) {
+    throw new Error('ts/dist not found — run npm run build before api tests');
+  }
+});
+
+describe('sanitizeScanTarget', () => {
+  it('accepts npm package specs without resolving under scan root', () => {
+    const result = sanitizeScanTarget('lodash@4.17.21', scanRoot);
+    expect(result).toEqual({ display: 'lodash@4.17.21', resolved: 'lodash@4.17.21' });
+  });
+
+  it('accepts scoped npm package specs', () => {
+    const result = sanitizeScanTarget('@types/node@20.0.0', scanRoot);
+    expect(result).toEqual({ display: '@types/node@20.0.0', resolved: '@types/node@20.0.0' });
+  });
+
+  it('rejects path traversal for filesystem targets', () => {
+    expect(() => sanitizeScanTarget('../outside', scanRoot)).toThrow(
+      'inside configured scan root'
+    );
+  });
+
+  it('rejects invalid npm package names', () => {
+    expect(() => sanitizeScanTarget('evil;curl', scanRoot)).toThrow('Invalid npm package name');
+  });
+});

--- a/packages/api/test/security-hardening.test.ts
+++ b/packages/api/test/security-hardening.test.ts
@@ -82,6 +82,16 @@ describe('API security hardening', () => {
     expect(res.body.error).toContain('inside configured scan root');
   });
 
+  it('rejects invalid npm package name targets in /scan', async () => {
+    const res = await request(app)
+      .post('/scan')
+      .set(authHeaders(orgAId))
+      .send({ target: 'evil;curl' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Invalid npm package name');
+  });
+
   it('blocks cross-tenant access to scan details and reports', async () => {
     const scanId = `scan-${Date.now()}-tenant`;
     await db.insertScan({

--- a/ts/src/lib/pathSecurity.ts
+++ b/ts/src/lib/pathSecurity.ts
@@ -372,22 +372,57 @@ export function validatePackageName(packageName: string): boolean {
     return false;
   }
 
-  // Check for path traversal in package name
   for (const pattern of PATH_SECURITY_CONFIG.traversalPatterns) {
     if (pattern.test(packageName)) {
       return false;
     }
   }
 
-  // Check for command injection patterns
   for (const pattern of PATH_SECURITY_CONFIG.injectionPatterns) {
     if (pattern.test(packageName)) {
       return false;
     }
   }
 
-  // Check against npm package name rules
+  if (packageName.startsWith('@')) {
+    const slashIndex = packageName.indexOf('/');
+    if (slashIndex <= 1 || slashIndex === packageName.length - 1) {
+      return false;
+    }
+    const scope = packageName.slice(1, slashIndex);
+    const name = packageName.slice(slashIndex + 1);
+    return (
+      VALIDATION_CONFIG.PACKAGE_NAME_PATTERN.test(scope) &&
+      VALIDATION_CONFIG.PACKAGE_NAME_PATTERN.test(name)
+    );
+  }
+
   return VALIDATION_CONFIG.PACKAGE_NAME_PATTERN.test(packageName);
+}
+
+export function assertSafeTarballEntry(entryPath: string, extractRoot: string): void {
+  if (!entryPath || entryPath.includes('\0')) {
+    throw new PathTraversalError('Invalid tarball entry path', entryPath, extractRoot);
+  }
+
+  const normalized = entryPath.replace(/\\/g, '/');
+  if (normalized.startsWith('/') || /^[a-zA-Z]:/.test(normalized)) {
+    throw new PathTraversalError('Absolute path in tarball entry', entryPath, extractRoot);
+  }
+
+  if (normalized.split('/').some((segment) => segment === '..')) {
+    throw new PathTraversalError('Parent traversal in tarball entry', entryPath, extractRoot);
+  }
+
+  const resolvedRoot = path.resolve(extractRoot);
+  const resolvedEntry = path.resolve(extractRoot, entryPath);
+  if (resolvedEntry !== resolvedRoot && !resolvedEntry.startsWith(resolvedRoot + path.sep)) {
+    throw new PathTraversalError(
+      'Tarball entry escapes extraction directory',
+      entryPath,
+      resolvedEntry
+    );
+  }
 }
 
 /**

--- a/ts/src/lib/remotePackageScan.ts
+++ b/ts/src/lib/remotePackageScan.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as https from 'https';
 import * as tar from 'tar';
 import { createLogger } from './logger';
+import { assertSafeTarballEntry, validatePackageName } from './pathSecurity';
 
 const logger = createLogger('remotePackageScan');
 
@@ -110,6 +111,11 @@ export async function downloadPackageToTemp(
   packageName: string,
   version = 'latest'
 ): Promise<ResolvedRemotePackage | null> {
+  if (!validatePackageName(packageName)) {
+    logger.warn(`Rejected invalid package name: ${packageName}`);
+    return null;
+  }
+
   const metadata = await fetchRegistryMetadata(packageName);
   if (!metadata) return null;
 
@@ -125,14 +131,6 @@ export async function downloadPackageToTemp(
   const tarball = await fetchBuffer(tarballUrl);
   const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nullvoid-pkg-'));
   const tarballPath = path.join(os.tmpdir(), `nullvoid-dl-${Date.now()}.tgz`);
-  fs.writeFileSync(tarballPath, tarball);
-  await tar.extract({ file: tarballPath, cwd: extractDir, strip: 1 });
-  try {
-    fs.unlinkSync(tarballPath);
-  } catch {
-    /* ignore */
-  }
-
   const cleanup = () => {
     try {
       fs.rmSync(extractDir, { recursive: true, force: true });
@@ -140,6 +138,37 @@ export async function downloadPackageToTemp(
       logger.warn(`Failed to remove temp package dir: ${(error as Error).message}`);
     }
   };
+
+  try {
+    fs.writeFileSync(tarballPath, tarball);
+    await tar.extract({
+      file: tarballPath,
+      cwd: extractDir,
+      strip: 1,
+      onentry(entry) {
+        try {
+          assertSafeTarballEntry(entry.path, extractDir);
+        } catch (error) {
+          entry.destroy(error as Error);
+        }
+      },
+    });
+  } catch (error) {
+    cleanup();
+    try {
+      fs.unlinkSync(tarballPath);
+    } catch {
+      /* ignore */
+    }
+    logger.warn(`Failed to extract package tarball: ${(error as Error).message}`);
+    return null;
+  }
+
+  try {
+    fs.unlinkSync(tarballPath);
+  } catch {
+    /* ignore */
+  }
 
   return {
     extractDir,

--- a/ts/test/integration/scan.test.ts
+++ b/ts/test/integration/scan.test.ts
@@ -3,8 +3,9 @@
  * Migrated from test/integration/scan.test.js to TypeScript
  */
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
 import { scan } from '../../src/scan';
+import * as remotePackageScan from '../../src/lib/remotePackageScan';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -90,6 +91,37 @@ describe('Scan Integration Tests', () => {
       expect(result.threats.length).toBeGreaterThan(0);
       expect(result.threats[0]?.type).toBe('MALICIOUS_CODE_STRUCTURE');
       expect(result.threats[0]?.severity).toBe('CRITICAL');
+    });
+
+    it('should scan a remote npm package spec via tarball extract', async () => {
+      const maliciousFile = path.join(tempDir, 'malicious.js');
+      fs.writeFileSync(
+        maliciousFile,
+        `
+        const _0x112fa8 = "malicious";
+        const fs = require('fs');
+        eval("malicious code");
+      `
+      );
+
+      const downloadSpy = jest.spyOn(remotePackageScan, 'downloadPackageToTemp').mockResolvedValue({
+        extractDir: tempDir,
+        packageName: 'mock-malware',
+        version: '1.0.0',
+        cleanup: () => undefined,
+      });
+
+      const result = await scan('mock-malware@1.0.0', {
+        verbose: false,
+        iocEnabled: false,
+        all: false,
+      });
+
+      expect(downloadSpy).toHaveBeenCalledWith('mock-malware', '1.0.0');
+      expect(result.filesScanned).toBeGreaterThan(0);
+      expect(result.threats.length).toBeGreaterThan(0);
+      expect(result.metadata?.['target']).toBe('mock-malware@1.0.0');
+      downloadSpy.mockRestore();
     });
   });
 

--- a/ts/test/unit/path-security-package-name.test.ts
+++ b/ts/test/unit/path-security-package-name.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from '@jest/globals';
+import { validatePackageName } from '../../src/lib/pathSecurity';
+
+describe('validatePackageName', () => {
+  it('accepts unscoped npm package names', () => {
+    expect(validatePackageName('lodash')).toBe(true);
+    expect(validatePackageName('express')).toBe(true);
+  });
+
+  it('accepts scoped npm package names', () => {
+    expect(validatePackageName('@types/node')).toBe(true);
+    expect(validatePackageName('@babel/core')).toBe(true);
+  });
+
+  it('rejects traversal and injection patterns', () => {
+    expect(validatePackageName('../evil')).toBe(false);
+    expect(validatePackageName('pkg;curl')).toBe(false);
+  });
+});

--- a/ts/test/unit/path-security-tarball.test.ts
+++ b/ts/test/unit/path-security-tarball.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from '@jest/globals';
+import { assertSafeTarballEntry, PathTraversalError } from '../../src/lib/pathSecurity';
+import * as os from 'os';
+import * as path from 'path';
+
+describe('assertSafeTarballEntry', () => {
+  const extractRoot = path.join(os.tmpdir(), 'nullvoid-tarball-test');
+
+  it('allows paths inside the extraction root', () => {
+    expect(() => assertSafeTarballEntry('package/index.js', extractRoot)).not.toThrow();
+    expect(() => assertSafeTarballEntry('lib/utils.js', extractRoot)).not.toThrow();
+  });
+
+  it('rejects parent directory traversal', () => {
+    expect(() => assertSafeTarballEntry('../outside.js', extractRoot)).toThrow(PathTraversalError);
+  });
+
+  it('rejects absolute paths', () => {
+    expect(() => assertSafeTarballEntry('/etc/passwd', extractRoot)).toThrow(PathTraversalError);
+  });
+
+  it('rejects null bytes', () => {
+    expect(() => assertSafeTarballEntry('pkg/\0.js', extractRoot)).toThrow(PathTraversalError);
+  });
+});

--- a/ts/test/unit/remote-package-scan.test.ts
+++ b/ts/test/unit/remote-package-scan.test.ts
@@ -1,22 +1,46 @@
 import { describe, it, expect } from '@jest/globals';
-import { isNpmPackageSpec, parsePackageSpec, resolveVersion } from '../../src/lib/remotePackageScan';
+import {
+  isNpmPackageSpec,
+  parsePackageSpec,
+  resolveVersion,
+  downloadPackageToTemp,
+} from '../../src/lib/remotePackageScan';
 
 describe('remotePackageScan', () => {
   it('detects npm package specs', () => {
     expect(isNpmPackageSpec('lodash')).toBe(true);
     expect(isNpmPackageSpec('lodash@4.17.21')).toBe(true);
     expect(isNpmPackageSpec('@types/node')).toBe(true);
+    expect(isNpmPackageSpec('@types/node@20.0.0')).toBe(true);
     expect(isNpmPackageSpec('./src')).toBe(false);
     expect(isNpmPackageSpec('/tmp/foo')).toBe(false);
+    expect(isNpmPackageSpec('scope/pkg')).toBe(false);
   });
 
   it('parses name and version', () => {
     expect(parsePackageSpec('express@4.18.2')).toEqual({ name: 'express', version: '4.18.2' });
     expect(parsePackageSpec('chalk')).toEqual({ name: 'chalk', version: 'latest' });
+    expect(parsePackageSpec('@scope/pkg@1.0.0')).toEqual({
+      name: '@scope/pkg',
+      version: '1.0.0',
+    });
   });
 
   it('resolves latest from dist-tags', () => {
     const meta = { 'dist-tags': { latest: '2.0.0' }, versions: { '2.0.0': {} } };
     expect(resolveVersion(meta, 'latest')).toBe('2.0.0');
   });
+
+  it('rejects invalid package names before network fetch', async () => {
+    await expect(downloadPackageToTemp('../evil')).resolves.toBeNull();
+    await expect(downloadPackageToTemp('pkg;curl')).resolves.toBeNull();
+  });
+
+  it('accepts scoped package names for validation', () => {
+    expect(parsePackageSpec('@types/node@20.0.0')).toEqual({
+      name: '@types/node',
+      version: '20.0.0',
+    });
+  });
 });
+


### PR DESCRIPTION
## Summary

- Harden remote package download with `validatePackageName`, scoped-name support, and zip-slip protection via `assertSafeTarballEntry` during tarball extraction
- Allow npm package specs (`lodash@4.17.21`, `@types/node`) as scan targets in the REST API via `scanTarget.ts`
- Add unit/integration/API tests and remove the resolved roadmap gap from `ADVANCED_ROADMAP.md`

## Roadmap

Closes #24

Epic: Remote npm package scanning
Project: https://github.com/users/kurt-grung/projects/3

## Test plan

- [x] `/regression` — CI parity + performance
- [x] Unit tests for tarball path security, package name validation, and API target sanitization
- [x] Integration test for remote package scan flow (mocked tarball download)