### PR TITLE
feat: Add performance regression suite with CI gate (#26)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,28 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
+  performance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run performance benchmarks
+        run: npm run test:performance
+        env:
+          CI: true
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -22,4 +22,7 @@ bash .github/scripts/verify-unit-test-isolation.sh
 echo "==> test"
 npm test
 
+echo "==> test:performance"
+npm run test:performance
+
 echo "ci-check: all passed"

--- a/ts/jest.config.js
+++ b/ts/jest.config.js
@@ -32,9 +32,14 @@ module.exports = {
       displayName: 'integration',
       testMatch: [
         '<rootDir>/test/integration/**/*.test.ts',
-        '<rootDir>/test/performance/**/*.test.ts',
         '<rootDir>/src/test/integration/**/*.test.ts',
       ],
+      testTimeout: 60000,
+    },
+    {
+      ...shared,
+      displayName: 'performance',
+      testMatch: ['<rootDir>/test/performance/**/*.test.ts'],
       testTimeout: 60000,
     },
   ],

--- a/ts/test/performance/ioc-batching-benchmark.test.ts
+++ b/ts/test/performance/ioc-batching-benchmark.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from '@jest/globals';
+import { RequestBatcher } from '../../src/lib/network/requestBatcher';
+
+const IOC_PROVIDER_BASE = 'https://services.nvd.nist.gov/rest/json/cves/2.0';
+const REQUEST_COUNT = 100;
+const MAX_DURATION_MS = 5_000;
+
+describe('IoC request batching performance', () => {
+  it(`batches ${REQUEST_COUNT} provider requests under ${MAX_DURATION_MS}ms`, async () => {
+    const batcher = new RequestBatcher({ maxBatchSize: 10, batchTimeout: 50 });
+    const start = Date.now();
+    const results = await Promise.all(
+      Array.from({ length: REQUEST_COUNT }, (_, index) =>
+        batcher.addRequest(
+          `${IOC_PROVIDER_BASE}?cveId=CVE-2024-${String(index).padStart(5, '0')}`,
+          { priority: 1 },
+          async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+            return { cve: index };
+          }
+        )
+      )
+    );
+    const duration = Date.now() - start;
+    expect(results).toHaveLength(REQUEST_COUNT);
+    expect(duration).toBeLessThan(MAX_DURATION_MS);
+  }, MAX_DURATION_MS + 2_000);
+});

--- a/ts/test/performance/parallel-workers-benchmark.test.ts
+++ b/ts/test/performance/parallel-workers-benchmark.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from '@jest/globals';
+import { scan } from '../../src/scan';
+import {
+  chunkPackages,
+  getOptimalChunkSize,
+  getOptimalWorkerCount,
+} from '../../src/lib/parallel';
+
+const SCAN_CEILING_MS = 30_000;
+
+describe('parallel worker performance', () => {
+  it('getOptimalWorkerCount stays within configured bounds', () => {
+    const count = getOptimalWorkerCount();
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(count).toBeLessThanOrEqual(8);
+  });
+
+  it('chunkPackages distributes items without loss', () => {
+    const items = Array.from({ length: 47 }, (_, index) => index);
+    const workerCount = getOptimalWorkerCount();
+    const chunkSize = getOptimalChunkSize(items.length, workerCount);
+    const chunks = chunkPackages(items, chunkSize);
+    const flattened = chunks.flat();
+    expect(flattened).toHaveLength(items.length);
+    expect([...flattened].sort((a, b) => a - b)).toEqual(items);
+  });
+
+  it(`parallel scan completes under ${SCAN_CEILING_MS}ms on fixtures`, async () => {
+    const fixtures = `${__dirname}/../fixtures`;
+    const start = Date.now();
+    const result = await scan(fixtures, { depth: 1, iocEnabled: false, parallel: true });
+    const duration = Date.now() - start;
+    expect(result).toBeDefined();
+    expect(duration).toBeLessThan(SCAN_CEILING_MS);
+  }, SCAN_CEILING_MS + 5_000);
+});


### PR DESCRIPTION
## Summary

- Add IoC batching and parallel worker performance benchmarks under `ts/test/performance/`
- Split performance tests into a dedicated Jest project for clearer isolation
- Gate CI with a new **Tests / performance** job and include benchmarks in `ci:check`

## Roadmap

Closes #26

Epic: Performance regression suite
Project: https://github.com/users/kurt-grung/projects/3

## Test plan

- [x] `/regression` — CI parity + performance
- [x] `npm run test:performance` — 5 benchmarks pass locally