### PR TITLE
feat: Wire custom rule engine into CLI and API (#27)

### DIFF
--- a/packages/api/src/customRules.ts
+++ b/packages/api/src/customRules.ts
@@ -1,0 +1,113 @@
+import * as path from 'path';
+
+const tsDist = path.resolve(__dirname, '../../../ts/dist');
+
+type EnhancedRules = Record<
+  string,
+  {
+    patterns: string[];
+    severity: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+    description: string;
+    confidence_threshold: number;
+  }
+>;
+
+type RulesModule = {
+  parseRulesObject: (value: unknown) => EnhancedRules;
+  validateRules: (rules: EnhancedRules) => { valid: boolean; errors: string[] };
+  loadRules: (
+    rulesPath: string,
+    options?: { mergeWithDefaults?: boolean; validateRules?: boolean }
+  ) => EnhancedRules;
+  createExampleRules: (outputPath: string, format: 'json' | 'yaml') => void;
+};
+
+type ScanRulesOptions = {
+  rulesFile?: string;
+  rules?: Record<string, unknown>;
+  mergeRulesWithDefaults?: boolean;
+  validateRules?: boolean;
+};
+
+let rulesModule: RulesModule | null = null;
+
+function getRulesModule(): RulesModule {
+  if (!rulesModule) {
+    rulesModule = require(path.join(tsDist, 'lib/rules')) as RulesModule;
+  }
+  return rulesModule;
+}
+
+export type ScanRulesInput = {
+  rulesFile?: string;
+  rules?: unknown;
+  mergeRulesWithDefaults?: boolean;
+};
+
+export function buildScanRulesOptions(
+  body: ScanRulesInput | undefined,
+  scanRoot: string
+): ScanRulesOptions {
+  if (!body?.rulesFile && body?.rules === undefined) {
+    return {};
+  }
+
+  const options: ScanRulesOptions = {
+    mergeRulesWithDefaults: body.mergeRulesWithDefaults !== false,
+    validateRules: true,
+  };
+
+  if (body.rulesFile) {
+    const { sanitizeRulesFilePath } = require('./scanTarget') as {
+      sanitizeRulesFilePath: (raw: unknown, root: string) => string;
+    };
+    options.rulesFile = sanitizeRulesFilePath(body.rulesFile, scanRoot);
+    const fs = require('fs') as typeof import('fs');
+    if (!fs.existsSync(options.rulesFile)) {
+      throw new Error(`Rules file not found: ${body.rulesFile}`);
+    }
+    const { loadRules, validateRules } = getRulesModule();
+    const parsed = loadRules(options.rulesFile, {
+      mergeWithDefaults: options.mergeRulesWithDefaults !== false,
+    });
+    const { valid, errors } = validateRules(parsed);
+    if (!valid) {
+      throw new Error(errors.join('; '));
+    }
+  }
+
+  if (body.rules !== undefined) {
+    const { parseRulesObject, validateRules } = getRulesModule();
+    const parsed = parseRulesObject(body.rules);
+    const { valid, errors } = validateRules(parsed);
+    if (!valid) {
+      throw new Error(errors.join('; '));
+    }
+    options.rules = parsed as unknown as Record<string, unknown>;
+  }
+
+  return options;
+}
+
+export function validateRulesPayload(body: unknown): { valid: boolean; errors: string[] } {
+  const { parseRulesObject, validateRules } = getRulesModule();
+  try {
+    const parsed = parseRulesObject(body);
+    return validateRules(parsed);
+  } catch (error) {
+    return { valid: false, errors: [(error as Error).message] };
+  }
+}
+
+export function rulesTemplate(format: 'json' | 'yaml'): string {
+  const fs = require('fs') as typeof import('fs');
+  const os = require('os') as typeof import('os');
+  const tmpPath = path.join(
+    os.tmpdir(),
+    `nullvoid-rules-template-${Date.now()}.${format === 'json' ? 'json' : 'yml'}`
+  );
+  getRulesModule().createExampleRules(tmpPath, format);
+  const content = fs.readFileSync(tmpPath, 'utf8');
+  fs.rmSync(tmpPath, { force: true });
+  return content;
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -30,6 +30,7 @@ import {
 import { registerEnterpriseRoutes, dispatchWebhooks, appendAudit } from './enterprise/routes';
 import { startScheduleRunner } from './enterprise/jobs';
 import { sanitizeScanTarget } from './scanTarget';
+import { buildScanRulesOptions, validateRulesPayload, rulesTemplate } from './customRules';
 
 /** Wrap async route handlers so rejections reach error middleware */
 const asyncHandler =
@@ -58,13 +59,16 @@ const corsOrigin = process.env['CORS_ORIGIN'] ?? '*';
 if (corsOrigin === '*' && process.env['NODE_ENV'] === 'production') {
   console.warn(
     '[nullvoid-api] CORS_ORIGIN is unset; defaulting to wildcard (*). ' +
-    'Set CORS_ORIGIN to an explicit origin in production.'
+      'Set CORS_ORIGIN to an explicit origin in production.'
   );
 }
 app.use((req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', corsOrigin);
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-API-Key, X-Organization-Id, X-Team-Id, X-NullVoid-Role');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Content-Type, X-API-Key, X-Organization-Id, X-Team-Id, X-NullVoid-Role'
+  );
   if (req.method === 'OPTIONS') {
     res.sendStatus(204);
     return;
@@ -104,7 +108,8 @@ const openApiSpec = swaggerJsdoc({
     info: {
       title: 'NullVoid API',
       version: '1.0.0',
-      description: 'NullVoid security scanner REST API — scan orchestration, results, multi-tenant management, and ML operations.',
+      description:
+        'NullVoid security scanner REST API — scan orchestration, results, multi-tenant management, and ML operations.',
     },
     components: {
       securitySchemes: {
@@ -127,8 +132,24 @@ const openApiSpec = swaggerJsdoc({
         post: {
           summary: 'Trigger a synchronous scan',
           security: [{ apiKey: [] }],
-          requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', properties: { target: { type: 'string' } }, required: ['target'] } } } },
-          responses: { 200: { description: 'Scan result' }, 400: { description: 'Bad request' }, 401: { description: 'Unauthorized' }, 500: { description: 'Scan failed' } },
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { target: { type: 'string' } },
+                  required: ['target'],
+                },
+              },
+            },
+          },
+          responses: {
+            200: { description: 'Scan result' },
+            400: { description: 'Bad request' },
+            401: { description: 'Unauthorized' },
+            500: { description: 'Scan failed' },
+          },
         },
       },
       '/scan/{id}': {
@@ -136,7 +157,11 @@ const openApiSpec = swaggerJsdoc({
           summary: 'Get scan by ID',
           security: [{ apiKey: [] }],
           parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
-          responses: { 200: { description: 'Scan row' }, 403: { description: 'Forbidden' }, 404: { description: 'Not found' } },
+          responses: {
+            200: { description: 'Scan row' },
+            403: { description: 'Forbidden' },
+            404: { description: 'Not found' },
+          },
         },
       },
       '/scans': {
@@ -144,7 +169,11 @@ const openApiSpec = swaggerJsdoc({
           summary: 'List scans',
           security: [{ apiKey: [] }],
           parameters: [
-            { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 100, default: 50 } },
+            {
+              name: 'limit',
+              in: 'query',
+              schema: { type: 'integer', minimum: 1, maximum: 100, default: 50 },
+            },
             { name: 'offset', in: 'query', schema: { type: 'integer', minimum: 0, default: 0 } },
           ],
           responses: { 200: { description: 'List of scans' } },
@@ -156,30 +185,123 @@ const openApiSpec = swaggerJsdoc({
           security: [{ apiKey: [] }],
           parameters: [
             { name: 'scanId', in: 'path', required: true, schema: { type: 'string' } },
-            { name: 'format', in: 'query', schema: { type: 'string', enum: ['html', 'markdown'], default: 'html' } },
-            { name: 'compliance', in: 'query', schema: { type: 'string', enum: ['soc2', 'iso27001'] } },
+            {
+              name: 'format',
+              in: 'query',
+              schema: { type: 'string', enum: ['html', 'markdown'], default: 'html' },
+            },
+            {
+              name: 'compliance',
+              in: 'query',
+              schema: { type: 'string', enum: ['soc2', 'iso27001'] },
+            },
           ],
-          responses: { 200: { description: 'Report content' }, 400: { description: 'Scan not completed' }, 403: { description: 'Forbidden' }, 404: { description: 'Not found' } },
+          responses: {
+            200: { description: 'Report content' },
+            400: { description: 'Scan not completed' },
+            403: { description: 'Forbidden' },
+            404: { description: 'Not found' },
+          },
         },
       },
       '/organizations': {
-        get: { summary: 'List organizations (scoped to caller org when key is set)', security: [{ apiKey: [] }], responses: { 200: { description: 'List of organizations' } } },
-        post: { summary: 'Create organization', security: [{ apiKey: [] }], requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { name: { type: 'string' } } } } } }, responses: { 201: { description: 'Created' } } },
+        get: {
+          summary: 'List organizations (scoped to caller org when key is set)',
+          security: [{ apiKey: [] }],
+          responses: { 200: { description: 'List of organizations' } },
+        },
+        post: {
+          summary: 'Create organization',
+          security: [{ apiKey: [] }],
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: { type: 'object', properties: { name: { type: 'string' } } },
+              },
+            },
+          },
+          responses: { 201: { description: 'Created' } },
+        },
       },
       '/teams': {
-        get: { summary: 'List teams', security: [{ apiKey: [] }], parameters: [{ name: 'organizationId', in: 'query', schema: { type: 'string' } }], responses: { 200: { description: 'List of teams' } } },
-        post: { summary: 'Create team', security: [{ apiKey: [] }], requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { organizationId: { type: 'string' }, name: { type: 'string' } }, required: ['organizationId'] } } } }, responses: { 201: { description: 'Created' } } },
+        get: {
+          summary: 'List teams',
+          security: [{ apiKey: [] }],
+          parameters: [{ name: 'organizationId', in: 'query', schema: { type: 'string' } }],
+          responses: { 200: { description: 'List of teams' } },
+        },
+        post: {
+          summary: 'Create team',
+          security: [{ apiKey: [] }],
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { organizationId: { type: 'string' }, name: { type: 'string' } },
+                  required: ['organizationId'],
+                },
+              },
+            },
+          },
+          responses: { 201: { description: 'Created' } },
+        },
       },
-      '/ml/metrics': { get: { summary: 'ML training metadata', security: [{ apiKey: [] }], responses: { 200: { description: 'Training metrics' } } } },
-      '/ml/status': { get: { summary: 'ML service status', security: [{ apiKey: [] }], responses: { 200: { description: 'Status object' } } } },
-      '/ml/drift': { get: { summary: 'Model drift statistics', security: [{ apiKey: [] }], responses: { 200: { description: 'Drift result' }, 503: { description: 'ML_SERVICE_URL not set' } } } },
-      '/ml/feedback': { post: { summary: 'Submit prediction feedback', security: [{ apiKey: [] }], requestBody: { content: { 'application/json': { schema: { type: 'object', properties: { packageName: { type: 'string' }, version: { type: 'string' }, label: { type: 'integer', enum: [0, 1] }, scanId: { type: 'string' } }, required: ['packageName', 'version', 'label', 'scanId'] } } } }, responses: { 200: { description: 'ok' }, 400: { description: 'Invalid payload' } } } },
+      '/ml/metrics': {
+        get: {
+          summary: 'ML training metadata',
+          security: [{ apiKey: [] }],
+          responses: { 200: { description: 'Training metrics' } },
+        },
+      },
+      '/ml/status': {
+        get: {
+          summary: 'ML service status',
+          security: [{ apiKey: [] }],
+          responses: { 200: { description: 'Status object' } },
+        },
+      },
+      '/ml/drift': {
+        get: {
+          summary: 'Model drift statistics',
+          security: [{ apiKey: [] }],
+          responses: {
+            200: { description: 'Drift result' },
+            503: { description: 'ML_SERVICE_URL not set' },
+          },
+        },
+      },
+      '/ml/feedback': {
+        post: {
+          summary: 'Submit prediction feedback',
+          security: [{ apiKey: [] }],
+          requestBody: {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    packageName: { type: 'string' },
+                    version: { type: 'string' },
+                    label: { type: 'integer', enum: [0, 1] },
+                    scanId: { type: 'string' },
+                  },
+                  required: ['packageName', 'version', 'label', 'scanId'],
+                },
+              },
+            },
+          },
+          responses: { 200: { description: 'ok' }, 400: { description: 'Invalid payload' } },
+        },
+      },
     },
   },
   apis: [],
 });
 
-app.get('/api-docs.json', (_req: Request, res: Response) => { res.json(openApiSpec); });
+app.get('/api-docs.json', (_req: Request, res: Response) => {
+  res.json(openApiSpec);
+});
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(openApiSpec));
 
 function getTenantHeaders(req: Request): { organizationId?: string; teamId?: string } {
@@ -204,9 +326,7 @@ function requireTenantHeaders(
   return tenant;
 }
 
-function parseResultJson(
-  rawResultJson: string | null
-): Record<string, unknown> | undefined {
+function parseResultJson(rawResultJson: string | null): Record<string, unknown> | undefined {
   if (!rawResultJson) return undefined;
   try {
     return JSON.parse(rawResultJson) as Record<string, unknown>;
@@ -253,6 +373,8 @@ app.get('/', (_req: Request, res: Response) => {
       scans: 'GET /api/scans',
       scan: 'GET /api/scan/:id',
       triggerScan: 'POST /api/scan',
+      validateRules: 'POST /api/rules/validate',
+      rulesTemplate: 'GET /api/rules/template?format=yaml|json',
       report: 'GET /api/report/:scanId?format=html|markdown&compliance=soc2|iso27001',
       organizations: 'GET /api/organizations',
       teams: 'GET /api/teams',
@@ -267,11 +389,7 @@ app.get('/', (_req: Request, res: Response) => {
   });
 });
 
-function enforceTenantAccess(
-  req: Request,
-  orgId?: string | null,
-  teamId?: string | null
-): boolean {
+function enforceTenantAccess(req: Request, orgId?: string | null, teamId?: string | null): boolean {
   if (!API_KEY) return true;
   const { organizationId: reqOrg, teamId: reqTeam } = getTenantHeaders(req);
   if (!reqOrg || !orgId) return false;
@@ -279,6 +397,30 @@ function enforceTenantAccess(
   if (teamId && reqTeam !== teamId) return false;
   return true;
 }
+
+/** POST /rules/validate - validate custom detection rules (JSON/YAML body) */
+app.post(
+  '/rules/validate',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const result = validateRulesPayload(req.body?.rules ?? req.body);
+    if (result.valid) {
+      res.status(200).json({ valid: true, errors: [] });
+      return;
+    }
+    res.status(400).json({ valid: false, errors: result.errors });
+  })
+);
+
+/** GET /rules/template - example rules file for YAML or JSON */
+app.get('/rules/template', requireAuth, (req: Request, res: Response) => {
+  const format = req.query.format === 'json' ? 'json' : 'yaml';
+  const content = rulesTemplate(format);
+  res
+    .status(200)
+    .type(format === 'json' ? 'application/json' : 'text/yaml')
+    .send(content);
+});
 
 /** POST /scan - run scan synchronously (required for Vercel serverless; no background jobs) */
 app.post(
@@ -297,6 +439,21 @@ app.post(
         req.body?.target,
         SCAN_ROOT
       ));
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+      return;
+    }
+
+    let scanRulesOptions: ReturnType<typeof buildScanRulesOptions> = {};
+    try {
+      scanRulesOptions = buildScanRulesOptions(
+        {
+          rulesFile: req.body?.rulesFile as string | undefined,
+          rules: req.body?.rules,
+          mergeRulesWithDefaults: req.body?.mergeRulesWithDefaults as boolean | undefined,
+        },
+        SCAN_ROOT
+      );
     } catch (error) {
       res.status(400).json({ error: (error as Error).message });
       return;
@@ -326,7 +483,7 @@ app.post(
     });
     const scan = getScanFn();
     try {
-      const result = await scan(resolvedTarget, { depth: 5 });
+      const result = await scan(resolvedTarget, { depth: 5, ...scanRulesOptions });
       const completedAt = new Date().toISOString();
       await updateScan(id, {
         status: 'completed',
@@ -460,7 +617,8 @@ app.get(
       return;
     }
     if (!result.metadata) result.metadata = {};
-    (result.metadata as Record<string, unknown>)['target'] = (result.metadata as Record<string, unknown>)['target'] ?? row.target;
+    (result.metadata as Record<string, unknown>)['target'] =
+      (result.metadata as Record<string, unknown>)['target'] ?? row.target;
 
     const format = (req.query.format as string) || 'html';
     const compliance = req.query.compliance as 'soc2' | 'iso27001' | undefined;
@@ -475,7 +633,10 @@ app.get(
     if (format === 'markdown') {
       const md = reporting.generateMarkdownReport(result, opts);
       res.setHeader('Content-Type', 'text/markdown');
-      res.setHeader('Content-Disposition', `attachment; filename="nullvoid-${String(row.target).replace(/[^a-zA-Z0-9.-]/g, '_')}-report.md"`);
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="nullvoid-${String(row.target).replace(/[^a-zA-Z0-9.-]/g, '_')}-report.md"`
+      );
       res.send(md);
     } else {
       const html = reporting.generateHtmlReport(result, opts);
@@ -690,7 +851,9 @@ app.post(
       return;
     }
     try {
-      const { stdout, stderr } = await runMlCommand('node ts/dist/bin/nullvoid.js train-behavioral');
+      const { stdout, stderr } = await runMlCommand(
+        'node ts/dist/bin/nullvoid.js train-behavioral'
+      );
       res.json({ ok: true, stdout: stdout.trim(), stderr: stderr.trim() });
     } catch (err) {
       const e = err as { stdout?: string; stderr?: string; message?: string };

--- a/packages/api/src/scanTarget.ts
+++ b/packages/api/src/scanTarget.ts
@@ -56,3 +56,25 @@ export function sanitizeScanTarget(
   }
   return { display: normalizedInput, resolved };
 }
+
+export function sanitizeRulesFilePath(rawPath: unknown, scanRoot: string): string {
+  const candidate = typeof rawPath === 'string' ? rawPath.trim() : '';
+  if (!candidate) {
+    throw new Error('rulesFile must be a non-empty string');
+  }
+  if (candidate.includes('\0')) {
+    throw new Error('rulesFile contains invalid null byte');
+  }
+
+  const resolved = path.isAbsolute(candidate)
+    ? path.resolve(candidate)
+    : path.resolve(scanRoot, candidate);
+  const relative = path.relative(scanRoot, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`rulesFile must resolve inside configured scan root: ${scanRoot}`);
+  }
+  if (!resolved.endsWith('.json') && !resolved.endsWith('.yaml') && !resolved.endsWith('.yml')) {
+    throw new Error('rulesFile must be a .json, .yaml, or .yml file');
+  }
+  return resolved;
+}

--- a/packages/api/test/custom-rules.test.ts
+++ b/packages/api/test/custom-rules.test.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const fixturesTarget = 'ts/test/fixtures';
+
+describe('API custom rules', () => {
+  let dbPath: string;
+  let app: import('express').Application;
+
+  beforeAll(async () => {
+    dbPath = path.join(os.tmpdir(), `nullvoid-custom-rules-${Date.now()}.db`);
+    process.env['NULLVOID_DB_PATH'] = dbPath;
+    delete process.env['NULLVOID_API_KEY'];
+    process.env['NULLVOID_SCAN_ROOT'] = repoRoot;
+
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    app = require('../src/index');
+  });
+
+  afterAll(() => {
+    for (const suffix of ['', '-shm', '-wal']) {
+      const p = `${dbPath}${suffix}`;
+      if (fs.existsSync(p)) {
+        fs.rmSync(p, { force: true });
+      }
+    }
+  });
+
+  it('POST /rules/validate accepts valid inline rules', async () => {
+    const res = await request(app)
+      .post('/rules/validate')
+      .send({
+        rules: {
+          custom: {
+            patterns: ['eval\\s*\\('],
+            severity: 'HIGH',
+            description: 'eval',
+            confidence_threshold: 0.7,
+          },
+        },
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.valid).toBe(true);
+  });
+
+  it('POST /rules/validate rejects invalid rules', async () => {
+    const res = await request(app)
+      .post('/rules/validate')
+      .send({
+        rules: {
+          bad: {
+            patterns: ['('],
+            severity: 'HIGH',
+            description: 'bad regex',
+            confidence_threshold: 0.7,
+          },
+        },
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.valid).toBe(false);
+    expect(res.body.errors.length).toBeGreaterThan(0);
+  });
+
+  it('GET /rules/template returns YAML content', async () => {
+    const res = await request(app).get('/rules/template');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('detection_rules');
+  });
+
+  it('POST /scan applies inline custom rules', async () => {
+    const res = await request(app)
+      .post('/scan')
+      .send({
+        target: fixturesTarget,
+        mergeRulesWithDefaults: false,
+        rules: {
+          fixture_rule: {
+            patterns: ['hexArray'],
+            severity: 'HIGH',
+            description: 'fixture marker',
+            confidence_threshold: 0.8,
+          },
+        },
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('completed');
+    const types = (res.body.result?.threats ?? []).map((t: { type: string }) => t.type);
+    expect(types.some((t: string) => t.includes('FIXTURE_RULE'))).toBe(true);
+  });
+});

--- a/packages/api/test/scan-target.test.ts
+++ b/packages/api/test/scan-target.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { sanitizeScanTarget } from '../src/scanTarget';
+import { sanitizeScanTarget, sanitizeRulesFilePath } from '../src/scanTarget';
 
 const scanRoot = path.join(os.tmpdir(), 'nullvoid-scan-target-root');
 
@@ -28,5 +28,26 @@ describe('sanitizeScanTarget', () => {
 
   it('rejects invalid npm package names', () => {
     expect(() => sanitizeScanTarget('evil;curl', scanRoot)).toThrow('Invalid npm package name');
+  });
+});
+
+describe('sanitizeRulesFilePath', () => {
+  it('accepts rules files inside scan root', () => {
+    const rulesPath = path.join(scanRoot, 'custom-rules.json');
+    fs.writeFileSync(rulesPath, '{}');
+    expect(sanitizeRulesFilePath('custom-rules.json', scanRoot)).toBe(rulesPath);
+    fs.rmSync(rulesPath, { force: true });
+  });
+
+  it('rejects path traversal', () => {
+    expect(() => sanitizeRulesFilePath('../outside/rules.json', scanRoot)).toThrow(
+      'inside configured scan root'
+    );
+  });
+
+  it('rejects non-rules extensions', () => {
+    expect(() => sanitizeRulesFilePath('rules.txt', scanRoot)).toThrow(
+      'must be a .json, .yaml, or .yml file'
+    );
   });
 });

--- a/ts/src/bin/nullvoid.ts
+++ b/ts/src/bin/nullvoid.ts
@@ -1125,6 +1125,55 @@ program
     }
   });
 
+const rulesCmd = program.command('rules').description('Custom detection rules');
+
+rulesCmd
+  .command('validate')
+  .description('Validate a custom rules file (JSON or YAML)')
+  .argument('<file>', 'Rules file path')
+  .action((file: string) => {
+    try {
+      const { loadRules, validateRules } = require('../lib/rules') as typeof import('../lib/rules');
+      const rules = loadRules(path.resolve(file), {
+        mergeWithDefaults: false,
+        validateRules: false,
+      });
+      const { valid, errors } = validateRules(rules);
+      if (!valid) {
+        console.error('Invalid rules:');
+        for (const err of errors) {
+          console.error(`  - ${err}`);
+        }
+        process.exit(1);
+      }
+      console.log(`Rules valid (${Object.keys(rules).length} rule(s))`);
+      process.exit(0);
+    } catch (error) {
+      console.error('Error:', (error as Error).message);
+      process.exit(1);
+    }
+  });
+
+rulesCmd
+  .command('init')
+  .description('Write an example rules template file')
+  .argument('[file]', 'Output path', 'rules/custom-rules.yml')
+  .option('-f, --format <format>', 'json or yaml', 'yaml')
+  .action((file: string, options: { format?: string }) => {
+    try {
+      const { createExampleRules } = require('../lib/rules') as typeof import('../lib/rules');
+      const format = options.format === 'json' ? 'json' : 'yaml';
+      const outPath = path.resolve(file);
+      fs.mkdirSync(path.dirname(outPath), { recursive: true });
+      createExampleRules(outPath, format);
+      console.log(`Example rules written to ${outPath}`);
+      process.exit(0);
+    } catch (error) {
+      console.error('Error:', (error as Error).message);
+      process.exit(1);
+    }
+  });
+
 // Main scan command (default action)
 program
   .argument('[target]', 'Package name, directory, or file to scan (defaults to current directory)')

--- a/ts/src/lib/customRuleEngine.ts
+++ b/ts/src/lib/customRuleEngine.ts
@@ -3,6 +3,10 @@ export {
   applyRules,
   validateRules,
   createRulesEngine,
+  parseRulesObject,
+  parseRulesContent,
+  normalizeRules,
+  createExampleRules,
   ENHANCED_RULES,
   type RuleConfig,
   type EnhancedRules,
@@ -10,11 +14,37 @@ export {
   type RulesLoadingOptions,
 } from './rules';
 
-import { loadRules, applyRules, ENHANCED_RULES, type RulesLoadingOptions } from './rules';
-import type { Threat } from '../types/core';
+import {
+  loadRules,
+  applyRules,
+  mergeRules,
+  ENHANCED_RULES,
+  parseRulesObject,
+  type EnhancedRules,
+  type RulesLoadingOptions,
+} from './rules';
+import type { ScanOptions, Threat } from '../types/core';
 
 export interface CustomRuleEngineOptions extends RulesLoadingOptions {
   rulesPath?: string;
+  rules?: EnhancedRules;
+}
+
+export function resolveScanRules(options: ScanOptions): EnhancedRules | undefined {
+  if (options.rules) {
+    const parsed = parseRulesObject(options.rules);
+    return options.mergeRulesWithDefaults === false ? parsed : mergeRules(parsed);
+  }
+  if (options.rulesFile) {
+    const loadOpts: RulesLoadingOptions = {
+      mergeWithDefaults: options.mergeRulesWithDefaults !== false,
+    };
+    if (options.validateRules) {
+      loadOpts.validateRules = true;
+    }
+    return loadRules(options.rulesFile, loadOpts);
+  }
+  return undefined;
 }
 
 export function runCustomRuleEngine(
@@ -22,7 +52,8 @@ export function runCustomRuleEngine(
   filePath: string,
   options: CustomRuleEngineOptions = {}
 ): Threat[] {
-  const rules = options.rulesPath ? loadRules(options.rulesPath, options) : ENHANCED_RULES;
+  const rules =
+    options.rules ?? (options.rulesPath ? loadRules(options.rulesPath, options) : ENHANCED_RULES);
   const detections = applyRules(content, filePath, rules);
   return detections.map((d) => ({
     type: d.type as Threat['type'],
@@ -33,4 +64,19 @@ export function runCustomRuleEngine(
     details: d.details,
     confidence: Math.round(d.confidence * 100),
   }));
+}
+
+export function detectFileThreats(
+  content: string,
+  filePath: string,
+  options: ScanOptions,
+  detectMalware: (content: string, filePath?: string) => Threat[]
+): Threat[] {
+  const baseThreats = detectMalware(content, filePath);
+  const rules = resolveScanRules(options);
+  if (!rules) {
+    return baseThreats;
+  }
+  const customThreats = runCustomRuleEngine(content, filePath, { rules });
+  return [...baseThreats, ...customThreats];
 }

--- a/ts/src/lib/rules.ts
+++ b/ts/src/lib/rules.ts
@@ -271,38 +271,93 @@ export const ENHANCED_RULES: EnhancedRules = {
  * @param options - Loading options
  * @returns Parsed rules object
  */
+function parseRulesPayload(parsed: Record<string, unknown>): EnhancedRules {
+  const raw =
+    parsed['detection_rules'] && typeof parsed['detection_rules'] === 'object'
+      ? (parsed['detection_rules'] as Record<string, unknown>)
+      : parsed;
+  return normalizeRules(raw as Record<string, Partial<RuleConfig>>);
+}
+
+export function normalizeRuleConfig(rule: Partial<RuleConfig>): RuleConfig {
+  return {
+    patterns: Array.isArray(rule.patterns) ? rule.patterns : [],
+    severity: rule.severity ?? 'MEDIUM',
+    description: rule.description ?? '',
+    confidence_threshold:
+      typeof rule.confidence_threshold === 'number' ? rule.confidence_threshold : 0.5,
+    ...(rule.entropy_threshold !== undefined ? { entropy_threshold: rule.entropy_threshold } : {}),
+  };
+}
+
+export function normalizeRules(rules: Record<string, Partial<RuleConfig>>): EnhancedRules {
+  const normalized: EnhancedRules = {};
+  for (const [name, config] of Object.entries(rules)) {
+    if (config && typeof config === 'object') {
+      normalized[name] = normalizeRuleConfig(config);
+    }
+  }
+  return normalized;
+}
+
+export function parseRulesContent(
+  content: string,
+  format: 'json' | 'yaml' | 'auto' = 'auto'
+): EnhancedRules {
+  let parsed: Record<string, unknown>;
+  if (format === 'yaml') {
+    parsed = (yaml.load(content, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>) || {};
+  } else if (format === 'json') {
+    parsed = JSON.parse(content) as Record<string, unknown>;
+  } else {
+    const trimmed = content.trim();
+    parsed =
+      trimmed.startsWith('{') || trimmed.startsWith('[')
+        ? (JSON.parse(content) as Record<string, unknown>)
+        : (yaml.load(content, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>) || {};
+  }
+  return parseRulesPayload(parsed);
+}
+
+export function parseRulesObject(value: unknown): EnhancedRules {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Rules must be a JSON object');
+  }
+  return parseRulesPayload(value as Record<string, unknown>);
+}
+
 export function loadRules(rulesPath: string, options: RulesLoadingOptions = {}): EnhancedRules {
   if (!rulesPath || !fs.existsSync(rulesPath)) {
+    if (options.mergeWithDefaults === false) {
+      throw new Error(`Rules file not found: ${rulesPath}`);
+    }
     return ENHANCED_RULES;
   }
 
   try {
     const fileContent = fs.readFileSync(rulesPath, 'utf8');
     const ext = path.extname(rulesPath).toLowerCase();
+    const format =
+      options.format ??
+      (ext === '.yaml' || ext === '.yml' ? 'yaml' : ext === '.json' ? 'json' : 'auto');
+    const parsedRules = parseRulesContent(fileContent, format);
 
-    let parsedRules: Record<string, unknown>;
-
-    if (ext === '.yaml' || ext === '.yml' || options.format === 'yaml') {
-      parsedRules =
-        (yaml.load(fileContent, { schema: yaml.JSON_SCHEMA }) as Record<string, unknown>) || {};
-    } else if (ext === '.json' || options.format === 'json') {
-      parsedRules = JSON.parse(fileContent) as Record<string, unknown>;
-    } else {
-      throw new Error(`Unsupported file format: ${ext}`);
+    if (options.validateRules) {
+      const { valid, errors } = validateRules(parsedRules);
+      if (!valid) {
+        throw new Error(errors.join('; '));
+      }
     }
 
-    // Extract rules from nested structure if present
-    if (parsedRules['detection_rules']) {
-      parsedRules = parsedRules['detection_rules'] as Record<string, unknown>;
-    }
-
-    // Merge with defaults if requested
     if (options.mergeWithDefaults !== false) {
-      return mergeRules(parsedRules as EnhancedRules);
+      return mergeRules(parsedRules);
     }
 
-    return parsedRules as EnhancedRules;
+    return parsedRules;
   } catch (error) {
+    if (options.mergeWithDefaults === false) {
+      throw error;
+    }
     console.warn(`Warning: Could not load rules from ${rulesPath}: ${(error as Error).message}`);
     return ENHANCED_RULES;
   }

--- a/ts/src/scan.ts
+++ b/ts/src/scan.ts
@@ -14,6 +14,7 @@ import { validateScanOptions } from './lib/validation';
 import { isNullVoidCode } from './lib/nullvoidDetection';
 import { detectMalware } from './lib/detection';
 import { filterThreatsBySeverity } from './lib/detection';
+import { detectFileThreats } from './lib/customRuleEngine';
 import { queryIoCProviders, mergeIoCThreats } from './lib/iocScanIntegration';
 import { analyzeDependencyConfusion } from './lib/dependencyConfusion';
 import { getOptimalWorkerCount, getOptimalChunkSize, chunkPackages } from './lib/parallel';
@@ -57,6 +58,14 @@ const CODE_THREAT_TYPES = new Set([
   'DEPENDENCY_CONFUSION_PREDICTIVE_RISK',
 ]);
 
+function isCodeThreatType(type: string): boolean {
+  return (
+    CODE_THREAT_TYPES.has(type) ||
+    type.startsWith('ENHANCED_RULE_') ||
+    type.startsWith('AGGREGATE_')
+  );
+}
+
 function findPackageRoot(filePath: string): string | null {
   let dir = path.isAbsolute(filePath)
     ? path.dirname(filePath)
@@ -98,7 +107,7 @@ async function exportThreatsToTraining(
   const lines: string[] = [];
 
   for (const threat of threats) {
-    if (!threat.filePath || !CODE_THREAT_TYPES.has(threat.type)) continue;
+    if (!threat.filePath || !isCodeThreatType(threat.type)) continue;
     const pkgRoot = findPackageRoot(threat.filePath);
     if (!pkgRoot) continue;
     const pkgRootNorm = path.resolve(pkgRoot);
@@ -415,7 +424,7 @@ async function processPaths(
           }
           continue;
         }
-        const fileThreats = detectMalware(content, fullPath);
+        const fileThreats = detectFileThreats(content, fullPath, options, detectMalware);
         threats.push(...fileThreats);
         filesScanned++;
       } catch (error) {
@@ -441,7 +450,7 @@ async function processPaths(
           if (isNullVoidCode(fullPath)) {
             continue;
           }
-          const fileThreats = detectMalware(content, fullPath);
+          const fileThreats = detectFileThreats(content, fullPath, options, detectMalware);
           chunkThreats.push(...fileThreats);
           chunkScanned++;
         } catch (error) {
@@ -721,7 +730,7 @@ export async function scan(
                   const depConfusionThreats = await analyzeDependencyConfusion(packagesToAnalyze);
                   threats.push(...depConfusionThreats);
                   for (const t of depConfusionThreats) {
-                    if (t.filePath && CODE_THREAT_TYPES.has(t.type)) {
+                    if (t.filePath && isCodeThreatType(t.type)) {
                       const root = findPackageRoot(t.filePath);
                       if (root) depConfusionThreatPackageRoots.add(path.resolve(root));
                     }
@@ -750,7 +759,7 @@ export async function scan(
       if (fs.existsSync(target)) {
         try {
           const content = fs.readFileSync(target, 'utf8');
-          const fileThreats = detectMalware(content, target);
+          const fileThreats = detectFileThreats(content, target, options, detectMalware);
           threats.push(...fileThreats);
           filesScanned = 1;
         } catch (error) {

--- a/ts/src/types/core.ts
+++ b/ts/src/types/core.ts
@@ -29,6 +29,12 @@ export interface ScanOptions {
   debug?: boolean;
   /** Custom rules file */
   rulesFile?: string;
+  /** Inline custom rules (JSON/YAML object or detection_rules map) */
+  rules?: Record<string, unknown>;
+  /** Merge inline/file rules with built-in defaults (default: true) */
+  mergeRulesWithDefaults?: boolean;
+  /** Validate custom rules before scanning */
+  validateRules?: boolean;
   /** SARIF output file */
   sarifFile?: string;
   /** Output directory */

--- a/ts/test/unit/custom-rule-engine.test.ts
+++ b/ts/test/unit/custom-rule-engine.test.ts
@@ -1,5 +1,9 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { describe, it, expect } from '@jest/globals';
-import { runCustomRuleEngine } from '../../src/lib/customRuleEngine';
+import { runCustomRuleEngine, resolveScanRules, detectFileThreats } from '../../src/lib/customRuleEngine';
+import { detectMalware } from '../../src/lib/detection';
 
 describe('customRuleEngine', () => {
   it('matches enhanced wallet hijacking patterns', () => {
@@ -7,5 +11,64 @@ describe('customRuleEngine', () => {
     const threats = runCustomRuleEngine(content, 'pkg/index.js');
     expect(threats.length).toBeGreaterThan(0);
     expect(threats[0]?.type).toContain('WALLET_HIJACKING');
+  });
+
+  it('resolveScanRules returns undefined when no rules configured', () => {
+    expect(resolveScanRules({})).toBeUndefined();
+  });
+
+  it('resolveScanRules parses inline rules', () => {
+    const rules = resolveScanRules({
+      rules: {
+        acme_rule: {
+          patterns: ['acme-secret-token'],
+          severity: 'HIGH',
+          description: 'ACME token',
+          confidence_threshold: 0.8,
+        },
+      },
+      mergeRulesWithDefaults: false,
+    });
+    expect(rules?.['acme_rule']?.patterns).toEqual(['acme-secret-token']);
+  });
+
+  it('detectFileThreats merges custom rule hits with base detection', () => {
+    const content = 'const token = "acme-secret-token";';
+    const threats = detectFileThreats(content, 'pkg/index.js', {
+      rules: {
+        acme_rule: {
+          patterns: ['acme-secret-token'],
+          severity: 'HIGH',
+          description: 'ACME token',
+          confidence_threshold: 0.8,
+        },
+      },
+      mergeRulesWithDefaults: false,
+    }, detectMalware);
+    expect(threats.some((t) => t.type.includes('ACME_RULE'))).toBe(true);
+  });
+
+  it('loads rules from a file path', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nullvoid-rules-'));
+    const rulesPath = path.join(dir, 'rules.json');
+    fs.writeFileSync(
+      rulesPath,
+      JSON.stringify({
+        detection_rules: {
+          file_rule: {
+            patterns: ['file-only-pattern'],
+            severity: 'MEDIUM',
+            description: 'from file',
+            confidence_threshold: 0.6,
+          },
+        },
+      })
+    );
+    const threats = runCustomRuleEngine('file-only-pattern here', 'pkg/a.js', {
+      rulesPath,
+      mergeWithDefaults: false,
+    });
+    expect(threats.length).toBeGreaterThan(0);
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/ts/test/unit/rules.test.ts
+++ b/ts/test/unit/rules.test.ts
@@ -5,6 +5,8 @@ import {
   mergeRules,
   validateRules,
   loadRules,
+  parseRulesObject,
+  normalizeRules,
   type EnhancedRules,
 } from '../../src/lib/rules';
 
@@ -81,5 +83,34 @@ describe('loadRules', () => {
   it('returns ENHANCED_RULES when the path does not exist', () => {
     const rules = loadRules('/nonexistent/path/rules.json');
     expect(rules).toEqual(expect.objectContaining(ENHANCED_RULES));
+  });
+});
+
+describe('parseRulesObject', () => {
+  it('extracts detection_rules and normalizes defaults', () => {
+    const rules = parseRulesObject({
+      detection_rules: {
+        custom: {
+          patterns: ['evilPattern'],
+          severity: 'HIGH',
+          description: 'custom threat',
+        },
+      },
+    });
+    expect(rules['custom']?.confidence_threshold).toBe(0.5);
+    expect(rules['custom']?.patterns).toEqual(['evilPattern']);
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => parseRulesObject([])).toThrow('Rules must be a JSON object');
+  });
+});
+
+describe('normalizeRules', () => {
+  it('fills default confidence_threshold', () => {
+    const rules = normalizeRules({
+      x: { patterns: ['a'], severity: 'LOW', description: 'd' },
+    });
+    expect(rules['x']?.confidence_threshold).toBe(0.5);
   });
 });


### PR DESCRIPTION
## Summary

- Wire `rulesFile` / inline `rules` through the scan pipeline so custom YAML/JSON detection rules run alongside built-in malware detection
- Add API support: `POST /scan` accepts `rules`, `rulesFile`, and `mergeRulesWithDefaults`; new `POST /rules/validate` and `GET /rules/template` endpoints
- Add CLI `nullvoid rules validate` and `nullvoid rules init` for validation and template generation

## Roadmap

Closes #27

Epic: Custom rule engine
Project: https://github.com/users/kurt-grung/projects/3

## Test plan

- [x] `/regression` — CI parity + performance
- [x] Unit tests for rules parsing, scan integration, and API custom-rules endpoints
- [ ] Manual: `nullvoid rules init rules/custom.yml` then `nullvoid rules validate rules/custom.yml`
- [ ] Manual: `POST /scan` with inline `rules` object against a fixture directory